### PR TITLE
Create a /run/nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /app
 
 RUN pip install django
 
+RUN mkdir -p /run/nginx
 RUN mkdir /etc/nginx/sites-enabled
 RUN rm /etc/nginx/nginx.conf
 RUN ln -s /app/nginx/nginx.conf /etc/nginx/


### PR DESCRIPTION
After run I got this error
/usr/lib/python2.7/site-packages/supervisor/options.py:296: UserWarning: Supervisord is running as root and it is searching for its configuration file in default locations (including its current working directory); you probably want to specify a "-c" argument specifying an absolute path to a configuration file for improved security.
  'Supervisord is running as root and it is searching '
2016-10-24 15:22:48,169 CRIT Supervisor running as root (no user in config file)
2016-10-24 15:22:48,176 INFO supervisord started with pid 1
2016-10-24 15:22:49,179 INFO spawned: 'app-uwsgi' with pid 7
2016-10-24 15:22:49,182 INFO spawned: 'nginx-app' with pid 8
2016-10-24 15:22:49,262 INFO exited: nginx-app (exit status 1; not expected)
2016-10-24 15:22:50,714 INFO success: app-uwsgi entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2016-10-24 15:22:50,716 INFO spawned: 'nginx-app' with pid 26
2016-10-24 15:22:50,731 INFO exited: nginx-app (exit status 1; not expected)
2016-10-24 15:22:52,737 INFO spawned: 'nginx-app' with pid 27
2016-10-24 15:22:52,751 INFO exited: nginx-app (exit status 1; not expected)
2016-10-24 15:22:55,768 INFO spawned: 'nginx-app' with pid 28
2016-10-24 15:22:55,783 INFO exited: nginx-app (exit status 1; not expected)
2016-10-24 15:22:56,786 INFO gave up: nginx-app entered FATAL state, too many start retries too quickly

I think it is due to a version update of nginx 
a quick fix is to create the /run/nginx
